### PR TITLE
Flatten views

### DIFF
--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -10,6 +10,7 @@
 module Control.Monad.Logic.Sequence
 (   SeqT(..)
   , Seq
+  , View(..)
   , Queue
   , MSeq(..)
   , AsUnitLoop(..)
@@ -32,8 +33,10 @@ import Control.Monad.Trans (MonadTrans(..))
 import Control.Monad.Trans as Trans
 import Control.Monad.Logic.Class
 import Control.Monad.IO.Class ()
-import Data.TASequence.FastCatQueue as TA
-import Data.SequenceClass as S
+import Data.TASequence.FastCatQueue hiding ((:<))
+import qualified Data.TASequence.FastCatQueue as TA
+import Data.SequenceClass hiding ((:<))
+import qualified Data.SequenceClass as S
 
 import Control.Monad.Logic.Sequence.AsUnitLoop (AsUnitLoop (..))
 
@@ -60,7 +63,9 @@ type Queue = MSeq FastTCQueue
 
 newtype MSeq s a = MSeq { getMS :: s (AsUnitLoop a) () () }
 
-newtype SeqT m a = SeqT (Queue (m (Maybe (a, SeqT m a))))
+data View m a = Empty | a :< SeqT m a
+
+newtype SeqT m a = SeqT (Queue (m (View m a)))
 
 type Seq a = SeqT Identity a
 
@@ -94,18 +99,18 @@ instance TASequence s => T.Traversable (MSeq s) where
     EmptyL -> pure S.empty
     h S.:< t -> pure (S.<|) <*> h <*> T.sequenceA t
 
-fromView :: m (Maybe (a, SeqT m a)) -> SeqT m a
+fromView :: m (View m a) -> SeqT m a
 fromView = SeqT . singleton
 
-toView :: Monad m => SeqT m a -> m (Maybe (a, SeqT m a))
+toView :: Monad m => SeqT m a -> m (View m a)
 toView (SeqT s) = case viewl s of
-  EmptyL -> return Nothing
+  EmptyL -> return Empty
   h S.:< t -> h >>= \x -> case x of
-    Nothing -> toView (SeqT t)
-    Just (hi, SeqT ti) -> return (Just (hi, SeqT (ti S.>< t)))
+    Empty -> toView (SeqT t)
+    hi :< SeqT ti -> return (hi :< SeqT (ti S.>< t))
 
-single :: (MonadPlus mp, Monad m) => a -> m (Maybe (a, mp b))
-single a = return (Just (a, mzero))
+single :: Monad m => a -> m (View m a)
+single a = return (a :< mzero)
 
 instance Monad m => Functor (SeqT m) where
   fmap f xs = xs >>= return . f
@@ -117,15 +122,15 @@ instance Monad m => Applicative (SeqT m) where
 instance Monad m => Alternative (SeqT m) where
   empty = SeqT (MSeq tempty)
   (toView -> m) <|> n = fromView (m >>= \x -> case x of
-      Nothing -> toView n
-      Just (h,t) -> return (Just (h, cat t n)))
+      Empty -> toView n
+      h :< t -> return (h :< cat t n))
     where cat (SeqT l) (SeqT r) = SeqT (l S.>< r)
 
 instance Monad m => Monad (SeqT m) where
   return = fromView . single
   (toView -> m) >>= f = fromView (m >>= \x -> case x of
-    Nothing -> return Nothing
-    Just (h,t) -> toView (f h `mplus` (t >>= f)))
+    Empty -> return Empty
+    h :< t -> toView (f h `mplus` (t >>= f)))
 #if !MIN_VERSION_base(4,13,0)
   fail = Fail.fail
 #endif
@@ -152,11 +157,16 @@ instance MonadTrans SeqT where
   lift m = fromView (m >>= single)
 
 instance Monad m => MonadLogic (SeqT m) where
-  msplit (toView -> m) = lift m
+  {-# INLINE msplit #-}
+  msplit (toView -> m) = fromView $ do
+    r <- m
+    case r of
+      Empty -> single Nothing
+      a :< t -> single (Just (a, t))
 
 observeAllT :: Monad m => SeqT m a -> m [a]
 observeAllT (toView -> m) = m >>= go where
-  go (Just (a,t)) = liftM (a:) (observeAllT t)
+  go (a :< t) = liftM (a:) (observeAllT t)
   go _ = return []
 
 #if !MIN_VERSION_base(4,13,0)
@@ -165,18 +175,19 @@ observeT :: Monad m => SeqT m a -> m a
 observeT :: MonadFail m => SeqT m a -> m a
 #endif
 observeT (toView -> m) = m >>= go where
-  go (Just (a, _)) = return a
-  go _ = fail "No results."
+  go (a :< _) = return a
+  go Empty = fail "No results."
 
 observe :: Seq a -> a
 observe (toView -> m) = case runIdentity m of
-  Just (a, _) -> a
-  _ -> error "No results."
+  a :< _ -> a
+  Empty -> error "No results."
 
 observeMaybeT :: Monad m => SeqT m (Maybe a) -> m (Maybe a)
 observeMaybeT (toView -> m) = m >>= go where
-  go (Just (Just a, _)) = return (Just a)
-  go _ = return Nothing
+  go (Just a :< _) = return (Just a)
+  go (Nothing :< rest) = toView rest >>= go
+  go Empty = return Nothing
 
 observeMaybe :: Seq (Maybe a) -> Maybe a
 observeMaybe = runIdentity . observeMaybeT


### PR DESCRIPTION
Use a custom `View` type instead of wrapping `Maybe` around `(,)`.
This should be faster for everything except `msplit`, and not
terrible for that either.

Note: This is a breaking change, since `SeqT` is not abstract.