### PR TITLE
Streamline bind

### DIFF
--- a/src/Control/Monad/Logic/Sequence/Internal/Queue.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal/Queue.hs
@@ -84,10 +84,7 @@ instance TASequence s => Monoid (MSeq s a) where
 
 instance TASequence s => Functor (MSeq s) where
   {-# INLINEABLE fmap #-}
-  fmap f = go where
-    go q = case viewl q of
-      EmptyL -> S.empty
-      h S.:< t -> f h S.<| go t
+  fmap f (MSeq s) = MSeq (tmap (\(UL x) -> UL (f x)) s)
 
 instance TASequence s => F.Foldable (MSeq s) where
   {-# INLINEABLE foldMap #-}


### PR DESCRIPTION
* Remove a slightly-hidden `toView . fromView` from the implementation
  of `>>=` for `SeqT`.

* Make `fmap` for `SeqT` do the most natural thing, rather than
  restructuring the `SeqT`. Whether this is better or worse will
  depend on the exact situation, but my bet is it's usually better,
  and it's more what one expects from `fmap`.

* Add a few more method implementations that might or might not matter.

* Improve `fmap` for `MSeq`.