### PR TITLE
Add instances, compat

### DIFF
--- a/logict-sequence.cabal
+++ b/logict-sequence.cabal
@@ -38,6 +38,8 @@ source-repository head
 
 library
     exposed-modules:  Control.Monad.Logic.Sequence
+                    , Control.Monad.Logic.Sequence.Compat
+                    , Control.Monad.Logic.Sequence.Morph
                     , Control.Monad.Logic.Sequence.Internal
                     , Control.Monad.Logic.Sequence.Internal.Queue
                     , Control.Monad.Logic.Sequence.Internal.AsUnitLoop
@@ -51,7 +53,8 @@ library
     build-depends: mtl >=2.0 && <2.3
     build-depends: type-aligned >= 0.9.6 && < 0.10
     build-depends: sequence >= 0.9.8 && < 0.10
-    build-depends: logict
+    build-depends: logict >= 0.7.1.0 && < 0.8
+    build-depends: mmorph
 
     if impl(ghc < 8.0)
        build-depends: fail, transformers
@@ -76,6 +79,13 @@ test-suite logict-test
                   , hedgehog
                   , hspec
                   , hspec-hedgehog
+                  , hedgehog-fn
+                  , sequence
+                  , logict
+                  , transformers
+                  , mtl
+                  , mmorph
+
   -- Try to work around weird CI failure
   if impl(ghc == 8.4.4)
     build-depends:  vector-builder == 0.3.7.2

--- a/src/Control/Monad/Logic/Sequence/Compat.hs
+++ b/src/Control/Monad/Logic/Sequence/Compat.hs
@@ -1,0 +1,5 @@
+module Control.Monad.Logic.Sequence.Compat
+  ( fromSeqT
+  , toLogicT
+  , fromLogicT ) where
+import Control.Monad.Logic.Sequence.Internal

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -8,6 +8,9 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 #ifdef USE_PATTERN_SYNONYMS
 {-# LANGUAGE PatternSynonyms #-}
@@ -16,6 +19,7 @@
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE Safe #-}
 #endif
+{-# OPTIONS_HADDOCK not-home #-}
 
 module Control.Monad.Logic.Sequence.Internal
 (
@@ -41,6 +45,13 @@ module Control.Monad.Logic.Sequence.Internal
   , observe
   , observeMaybeT
   , observeMaybe
+  , fromSeqT
+  , hoistPre
+  , hoistPost
+  , hoistPreUnexposed
+  , hoistPostUnexposed
+  , toLogicT
+  , fromLogicT
 )
 where
 
@@ -50,11 +61,20 @@ import qualified Control.Monad.Fail as Fail
 import Control.Monad.Identity (Identity(..))
 import Control.Monad.Trans (MonadTrans(..))
 import Control.Monad.Logic.Class
+import qualified Control.Monad.Logic as L
 import Control.Monad.IO.Class
-import Data.SequenceClass hiding ((:<))
+import Control.Monad.Reader.Class (MonadReader (..))
+import Control.Monad.State.Class (MonadState (..))
+import Control.Monad.Error.Class (MonadError (..))
+import Control.Monad.Morph (MFunctor (..))
+import Data.SequenceClass hiding ((:<), empty)
 import qualified Data.SequenceClass as S
 import Control.Monad.Logic.Sequence.Internal.Queue
 import qualified Text.Read as TR
+import Data.Function (on)
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Classes
+#endif
 
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid (Monoid(..))
@@ -77,12 +97,34 @@ import GHC.Generics (Generic)
 
 data View m a = Empty | a :< SeqT m a
   deriving Generic
+infixl 5 :<
 
 deriving instance (Show a, Show (SeqT m a)) => Show (View m a)
 deriving instance (Read a, Read (SeqT m a)) => Read (View m a)
 deriving instance (Eq a, Eq (SeqT m a)) => Eq (View m a)
 deriving instance (Ord a, Ord (SeqT m a)) => Ord (View m a)
 deriving instance Monad m => Functor (View m)
+
+#if MIN_VERSION_base(4,9,0)
+instance (Eq1 m, Monad m) => Eq1 (View m) where
+  liftEq _ Empty Empty = True
+  liftEq eq (a :< s) (b :< t) = eq a b && liftEq eq s t
+  liftEq _ _ _ = False
+
+instance (Ord1 m, Monad m) => Ord1 (View m) where
+  liftCompare _ Empty Empty = EQ
+  liftCompare _ Empty (_ :< _) = LT
+  liftCompare cmp (a :< s) (b :< t) = cmp a b `mappend` liftCompare cmp s t
+  liftCompare _ (_ :< _) Empty = GT
+
+instance (Show1 m, Monad m) => Show1 (View m) where
+  liftShowsPrec sp sl d val = case val of
+    Empty -> ("Empty" ++)
+    a :< s -> showParen (d > 5) $
+      sp 6 a .
+      showString " :< " .
+      liftShowsPrec sp sl 6 s
+#endif
 
 -- | An asymptotically efficient logic monad transformer. It is generally best to
 -- think of this as being defined
@@ -172,6 +214,26 @@ instance Read (m (View m a)) => Read (SeqT m a) where
       m <- TR.step TR.readPrec
       return (fromView m)
     where app_prec = 10
+  readListPrec = TR.readListPrecDefault
+
+instance (Eq a, Eq (m (View m a)), Monad m) => Eq (SeqT m a) where
+  (==) = (==) `on` toView
+instance (Ord a, Ord (m (View m a)), Monad m) => Ord (SeqT m a) where
+  compare = compare `on` toView
+
+
+#if MIN_VERSION_base(4,9,0)
+instance (Eq1 m, Monad m) => Eq1 (SeqT m) where
+  liftEq eq s t = liftEq (liftEq eq) (toView s) (toView t)
+
+instance (Ord1 m, Monad m) => Ord1 (SeqT m) where
+  liftCompare eq s t = liftCompare (liftCompare eq) (toView s) (toView t)
+
+instance (Show1 m, Monad m) => Show1 (SeqT m) where
+  liftShowsPrec sp sl d s = showParen (d > app_prec) $
+      showString "MkSeqT " . liftShowsPrec (liftShowsPrec sp sl) (liftShowList sp sl) (app_prec + 1) (toView s)
+    where app_prec = 10
+#endif
 
 single :: Monad m => a -> m (View m a)
 single a = return (a :< mzero)
@@ -305,6 +367,93 @@ observeAll :: Seq a -> [a]
 observeAll = runIdentity . observeAllT
 {-# INLINE observeAll #-}
 
+-- | Convert @'SeqT' m a@ to @t m a@ when @t@ is some other logic monad
+-- transformer.
+fromSeqT :: (Monad m, Monad (t m), MonadTrans t, Alternative (t m)) => SeqT m a -> t m a
+fromSeqT (toView -> m) = lift m >>= \r -> case r of
+  Empty -> empty
+  a :< s -> pure a <|> fromSeqT s
+
+-- | Convert @'SeqT' m a@ to @'L.LogicT' m a@.
+--
+-- @ toLogicT = 'fromSeqT' @
+toLogicT :: Monad m => SeqT m a -> L.LogicT m a
+toLogicT = fromSeqT
+
+fromLogicT :: Monad m => L.LogicT m a -> SeqT m a
+fromLogicT (L.LogicT f) = fromView $ f (\a v -> return (a :< fromView v)) (return Empty)
+
+-- | 'hoist' is 'hoistPre'.
+instance MFunctor SeqT where
+  -- Note: if `f` is not a monad morphism, then hoist may not respect
+  -- (==). That is, it could be that
+  --
+  --   s == t = True
+  --
+  --  but
+  --
+  --   hoist f s == hoist f t = False..
+  --
+  -- This behavior is permitted by the MFunctor
+  -- documentation, and allows us to avoid restructuring
+  -- the SeqT.
+  hoist f = hoistPre f
+
+-- | This function is the implementation of 'hoist' for 'SeqT'. The passed
+-- function is required to be a monad morphism.
+hoistPre :: Monad m => (forall x. m x -> n x) -> SeqT m a -> SeqT n a
+hoistPre f (SeqT s) = SeqT $ fmap (f . liftM go) s
+  where
+    go Empty = Empty
+    go (a :< as) = a :< hoistPre f as
+
+-- | A version of `hoist` that uses the `Monad` instance for @n@
+-- rather than for @m@. Like @hoist@, the passed function is required
+-- to be a monad morphism.
+hoistPost :: Monad n => (forall x. m x -> n x) -> SeqT m a -> SeqT n a
+hoistPost f (SeqT s) = SeqT $ fmap (liftM go . f) s
+  where
+      go Empty = Empty
+      go (a :< as) = a :< hoistPost f as
+
+-- | A version of 'hoist' that works for arbitrary functions, rather
+-- than just monad morphisms.
+hoistPreUnexposed :: forall m n a. Monad m => (forall x. m x -> n x) -> SeqT m a -> SeqT n a
+hoistPreUnexposed f (toView -> m) = fromView $ f (liftM go m)
+  where
+      go Empty = Empty
+      go (a :< as) = a :< hoistPreUnexposed f as
+
+-- | A version of 'hoistPost' that works for arbitrary functions, rather
+-- than just monad morphisms. This should be preferred when the `Monad` instance
+-- for `n` is less expensive than that for `m`.
+hoistPostUnexposed :: forall m n a. (Monad m, Monad n) => (forall x. m x -> n x) -> SeqT m a -> SeqT n a
+hoistPostUnexposed f (toView -> m) = fromView $ liftM go (f m)
+  where
+      go Empty = Empty
+      go (a :< as) = a :< hoistPostUnexposed f as
+
 instance MonadIO m => MonadIO (SeqT m) where
   {-# INLINE liftIO #-}
   liftIO = lift . liftIO
+
+instance MonadReader e m => MonadReader e (SeqT m) where
+  -- TODO: write more thorough tests for this instance (issue #31)
+  ask = lift ask
+  local f (SeqT q) = SeqT $ fmap (local f . liftM go) q
+    where
+      go Empty = Empty
+      go (a :< s) = a :< local f s
+
+instance MonadState s m => MonadState s (SeqT m) where
+  get = lift get
+  put = lift . put
+  state = lift . state
+
+instance MonadError e m => MonadError e (SeqT m) where
+  -- TODO: write tests for this instance (issue #31)
+  throwError = lift . throwError
+  catchError (toView -> m) h = fromView $ (liftM go m) `catchError` (toView . h)
+    where
+      go Empty = Empty
+      go (a :< s) = a :< catchError s h

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -34,9 +34,6 @@ module Control.Monad.Logic.Sequence.Internal
   , getSeq
 #endif
   , View(..)
-  , Queue
-  , MSeq(..)
-  , AsUnitLoop(..)
   , toView
   , fromView
   , observeAllT
@@ -67,9 +64,8 @@ import Control.Monad.Reader.Class (MonadReader (..))
 import Control.Monad.State.Class (MonadState (..))
 import Control.Monad.Error.Class (MonadError (..))
 import Control.Monad.Morph (MFunctor (..))
-import Data.SequenceClass hiding ((:<), empty)
 import qualified Data.SequenceClass as S
-import Control.Monad.Logic.Sequence.Internal.Queue
+import Control.Monad.Logic.Sequence.Internal.Queue (Queue)
 import qualified Text.Read as TR
 import Data.Function (on)
 #if MIN_VERSION_base(4,9,0)
@@ -167,12 +163,12 @@ pattern MkSeq{getSeq} <- (runIdentity . toView -> getSeq)
 type Seq = SeqT Identity
 
 fromView :: m (View m a) -> SeqT m a
-fromView = SeqT . singleton
+fromView = SeqT . S.singleton
 {-# INLINE fromView #-}
 
 toView :: Monad m => SeqT m a -> m (View m a)
-toView (SeqT s) = case viewl s of
-  EmptyL -> return Empty
+toView (SeqT s) = case S.viewl s of
+  S.EmptyL -> return Empty
   h S.:< t -> h >>= \x -> case x of
     Empty -> toView (SeqT t)
     hi :< SeqT ti -> return (hi :< SeqT (ti S.>< t))

--- a/src/Control/Monad/Logic/Sequence/Morph.hs
+++ b/src/Control/Monad/Logic/Sequence/Morph.hs
@@ -1,0 +1,22 @@
+-- |
+-- This module provides functions for changing the underlying
+-- monad of a 'SeqT', just like "Control.Monad.Morph".'Control.Monad.Morph.hoist'.
+--
+-- The functions with the word \"Pre\" in their names lean on the
+-- `Monad` instance of the original monad. The ones with the word
+-- \"Post\" in their names lean on the `Monad` instance of the
+-- target monad. The ones with the word \"Unexposed\" in their names
+-- are reasonably well-behaved when the passed function is not
+-- a monad morphism (as described in the "Control.Monad.Morph" documentation).
+-- The others are typically a little more efficient, but may behave
+-- strangely when passed non-monad-morphisms. In particular, if @f@ is
+-- not a monad morphism, and @s1 == s2@, we do not even guarantee that
+-- @'hoistPre' f s1 == 'hoistPre' f s2@.
+module Control.Monad.Logic.Sequence.Morph
+  ( hoistPreUnexposed
+  , hoistPost
+  , hoistPostUnexposed
+  , hoistPre
+  ) where
+
+import Control.Monad.Logic.Sequence.Internal

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,7 +1,213 @@
+{-# language ScopedTypeVariables #-}
+{-# language DeriveGeneric #-}
+{-# language FlexibleContexts #-}
+{-# language UndecidableInstances #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language DeriveFunctor #-}
+{-# language StandaloneDeriving #-}
 module Main(main) where
 
-import Test.Hspec
+import Control.Monad.IO.Class (liftIO)
+import Hedgehog (MonadGen, Range)
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import Hedgehog.Range (Size)
+import qualified Hedgehog.Range as Range
+import Test.Hspec (before, describe, hspec, it, shouldBe)
+import Test.Hspec.Hedgehog (PropertyT, diff, forAll, hedgehog, (/==), (===))
+import Control.Monad.Logic.Sequence
+import Control.Monad.Logic.Sequence.Compat
+import Control.Monad.Logic.Sequence.Internal (SeqT (..))
+import Data.SequenceClass hiding ((:<), empty)
+import qualified Data.SequenceClass as S
+import Control.Monad.Logic.Sequence.Internal.Queue
+import Data.Functor.Identity
+import Control.Applicative
+import Data.Function (fix)
+import GHC.Generics (Generic)
+import qualified Hedgehog.Function as Fun
+import Data.Foldable (foldl', for_)
+import qualified Control.Monad.Logic as L
+import Debug.Trace (trace)
+import Control.Monad.Trans.Maybe
+import Control.Monad.Reader
+import Control.Monad.Except
+import Control.Monad.Morph (hoist)
+import Text.Read (readMaybe)
+
+-- | A generic "container" functor. We can use this with `Free` to get
+-- an inspectable `Monad` that's unlikely to hide any mistakes we make.
+data TestF a = TestF !Int [a]
+  deriving (Show, Read, Eq, Generic, Functor)
+
+instance Fun.Arg a => Fun.Arg (TestF a)
+
+
+-- Note: size
+--
+-- I've found it quite difficult to get a good range of
+-- sizes for SeqT TestM Int using the basic tools in
+-- Gen. Preventing almost all examples being tiny seems to lead to
+-- some examples being unmanageably enormous. So I've decided to
+-- go with a "nuclear option". First, I select the approximate total number
+-- of nodes in the SeqT. Then at each stage, the approximate total size is
+-- chosen in advance to make sure the target is met.
+
+-- | Generate a partition of a non-negative integer into positive
+-- integers. This is not statistically fair because I'm not that smart.
+splat :: MonadGen m => Size -> m [Size]
+splat 0 = pure []
+splat n = do
+  k <- Gen.integral (Range.constant 1 n)
+  rest <- splat (n - k)
+  pure (k : rest)
+
+genTestFSized :: MonadGen m => (Size -> m a) -> Size -> m (TestF a)
+genTestFSized m sz = do
+  i <- Gen.integral (Range.constant 1 10000)
+  part <- splat sz
+  goop <- traverse m part
+  pure (TestF i goop)
+
+newtype TestM a = TestM (Free TestF a)
+  deriving (Show, Read, Eq, Generic, Functor, Applicative, Monad)
+
+genTestMSized :: MonadGen m => (Size -> m a) -> Size -> m (TestM a)
+genTestMSized = \m sz -> TestM <$> go m sz
+  where
+    go :: MonadGen m => (Size -> m a) -> Size -> m (Free TestF a)
+    go m n | n <= 1 = Pure <$> m (n - 1)
+    go m n = Free <$> genTestFSized (go m) (n - 1)
+
+-- | Generate a test monad value.
+genTestM :: MonadGen m => m a -> m (TestM a)
+genTestM m = Gen.sized $ \sz -> do
+  true_size <- Gen.integral (Range.constant 0 sz)
+  genTestMSized (const m) true_size
+
+simpleTestM :: MonadGen m => m (TestM Int)
+simpleTestM = genTestM (Gen.integral $ Range.constant 0 5)
+
+listToQueue :: [a] -> Queue a
+listToQueue = foldl' (S.|>) S.empty
+
+genViewSized :: forall m a. MonadGen m => m a -> Size -> m (View TestM a)
+genViewSized _ sz | sz <= 1 = pure Empty
+genViewSized m sz = do
+  a <- m
+  s <- genSeqTSized m (sz - 1)
+  pure (a :< s)
+
+genSeqTSized :: forall m a. MonadGen m => m a -> Size -> m (SeqT TestM a)
+genSeqTSized m sz = do
+  part <- splat sz
+  goop <- traverse (genTestMSized (genViewSized m)) part
+  pure $ SeqT $ listToQueue goop
+
+genSeqT :: forall m a. MonadGen m => m a -> m (SeqT TestM a)
+genSeqT m = Gen.sized $ \sz -> do
+  tsz <- Gen.integral (Range.linear 0 sz)
+  genSeqTSized m tsz
+  
+simpleSeqT :: MonadGen m => m (SeqT TestM Int)
+simpleSeqT = genSeqT (Gen.integral $ Range.constant 0 5)
 
 main :: IO ()
 main = hspec $ do
-  return ()
+  describe "observe" $ do
+    it "undoes pure" $ hedgehog $
+      observe (pure (3 :: Int)) === 3
+  describe "observeT" $ do
+    it "undoes lift" $ hedgehog $ do
+      ex <- forAll simpleTestM
+      runMaybeT (observeT (lift (lift ex))) === runMaybeT (lift ex)
+  describe "observeAllT" $ do
+    it "undoes lift" $ hedgehog $ do
+      ex <- forAll simpleTestM
+      observeAllT (lift ex) === fmap (:[]) ex
+    it "works like logicT" $ hedgehog $ do
+      ex <- forAll simpleSeqT
+      observeAllT ex === L.observeAllT (fromSeqT ex)
+  describe "read" $ do
+    it "undoes show" $ hedgehog $ do
+      ex <- forAll simpleSeqT
+      readMaybe (show ex) === Just ex
+  describe ">>=" $ do
+    it "obeys monad identity law 1" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      (s >>= return) === s
+    it "obeys monad identity law 2" $ hedgehog $ do
+      a <- forAll $ Gen.integral Range.linearBounded
+      f :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      (pure a >>= f) === f a
+    it "works like LogicT" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      f :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      fromLogicT (toLogicT s >>= toLogicT . f) === (s >>= f)
+    it "obeys monad associativity law" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      f :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      g :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      ((s >>= f) >>= g) === (s >>= \a -> f a >>= g)
+    it "obeys left zero law" $ hedgehog $ do
+      f :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      (empty >>= f) === empty
+  describe "<|>" $ do
+    it "is associative" $ hedgehog $ do
+      s <- forAll (Gen.small simpleSeqT)
+      t <- forAll (Gen.small simpleSeqT)
+      u <- forAll (Gen.small simpleSeqT)
+      ((s <|> t) <|> u) === (s <|> (t <|> u))
+    it "obeys Alternative identity laws" $ hedgehog $ do
+      s <- forAll (Gen.small simpleSeqT)
+      (s <|> empty) === s
+      (empty <|> s) === s
+    it "obeys left distribution" $ hedgehog $ do
+      s <- forAll (Gen.small simpleSeqT)
+      t <- forAll (Gen.small simpleSeqT)
+      f :: Int -> SeqT TestM Int <- Fun.forAllFn (Fun.fn simpleSeqT)
+      ((s <|> t) >>= f) === ((s >>= f) <|> (t >>= f))
+    it "works like LogicT" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      t <- forAll simpleSeqT
+      (s <|> t) === fromLogicT (fromSeqT s <|> fromSeqT t)
+  describe "fromLogicT" $ do
+    it "reverses fromSeqT" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      fromLogicT (fromSeqT s) === s
+  describe "fromView" $ do
+    it "reverses toView" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      fromView (toView s) === s
+  describe "MonadReader instance" $ do
+    it "passes the tests in https://github.com/Bodigrim/logict/issues/1" $ do
+      runReader (runMaybeT (observeAllT (local (5+) ask))) 0 `shouldBe` Just [5]
+      let
+        foo :: MonadReader Int m => m (Int, Int)
+        foo = do
+          x <- local (5+) ask
+          y <- ask
+          return (x, y)
+      runReader (runMaybeT (observeT foo)) 0 `shouldBe` Just (5, 0)
+  describe "MFunctor instance" $ do
+    it "obeys the hoist identity law" $ hedgehog $ do
+      s <- forAll simpleSeqT
+      hoist (\x -> x) s === s
+
+
+
+-- -------
+-- Reimplementation of Control.Monad.Free without the need
+-- to futz with Data.Functor.Classes.
+
+data Free f a = Pure a | Free (f (Free f a))
+  deriving Functor
+deriving instance (Show a, Show (f (Free f a))) => Show (Free f a)
+deriving instance (Read a, Read (f (Free f a))) => Read (Free f a)
+deriving instance (Eq a, Eq (f (Free f a))) => Eq (Free f a)
+instance Functor f => Applicative (Free f) where
+  pure = Pure
+  (<*>) = ap
+instance Functor f => Monad (Free f) where
+  Pure a >>= f = f a
+  Free ffa >>= f = Free $ (>>= f) <$> ffa


### PR DESCRIPTION
Add instances, compat

* Add `mtl`-style instances. These should be checked for
  reasonableness!

* Finish adding `Eq` and `Ord` instances. Either I missed key
  bits the first time around or they were accidentally removed.

* Add conversions to and from `LogicT` and conversion to arbitrary
  logic monad transformers.

* Require `logict >= 0.7.1.0` for consistent `MonadLogic`
  superclasses.

* Add the beginnings of a test suite. This doesn't yet test
  the `MonadError` instance, and doesn't adequately test the
  `MonadReader` instance.

Starts to address #2
Closes #22
Closes #23
