### PR TITLE
A few performance related tweaks

### DIFF
--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -189,7 +189,7 @@ instance Monad m => Functor (SeqT m) where
 
 instance Monad m => Applicative (SeqT m) where
   {-# INLINEABLE pure #-}
-  {-# INLINABLE (<*>) #-}
+  {-# INLINEABLE (<*>) #-}
   pure = fromView . single
   (<*>) = ap
   (*>) = (>>)

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -224,14 +224,14 @@ instance Monad m => Monad (SeqT m) where
 #endif
 
 bind :: Monad m => SeqT m a -> (a -> SeqT m b) -> SeqT m b
-bind = go where
+bind m0 f0 = go m0 f0 where
   go m f = fromView $ toView m >>= \x -> case x of
     Empty -> return Empty
     h :< t -> f h `altView` (t `go` f)
 {-# INLINEABLE bind #-}
 
 then_ :: Monad m => SeqT m a -> SeqT m b -> SeqT m b
-then_ = go where
+then_ m0 n0 = go m0 n0 where
   go m n = fromView $ toView m >>= \x -> case x of
     Empty -> return Empty
     _ :< t -> n `altView` (t `go` n)


### PR DESCRIPTION
How does this look? I realize some of the changes might seem a little weird. I found that sometimes `INLINE` had worse performance than `INLINEABLE` so I just changed all the `INLINE` to `INLINEABLE` and the performance was either better or the same.

I found that this rule definitely fires a few times and makes a small improvement:

```haskell
"fromView-toView" [~0] forall m. toView (fromView m) = m;
```

I left this rule in but it has never fired for me and maybe I should remove it?

```haskell
"toView-fromView" [~0] forall m. fromView (toView m) = m;
```

I removed all the `SPECIALIZE` pragmas. The documentation says that if you mark something `INLINEABLE` the unfoldings become available anyway. So I don't think there is any performance gain to making something both `INLINEABLE` and `SPECIALIZE`, but I could be mistaken about that. I removed all of the `SPECIALIZE` and I didn't notice speed differences in my simple test.

For all the class methods that get hammered by my benchmark (mainly meaning: `>>=`, `>>`, and `<|>`), it does make a slight difference to break them out as standalone functions. I don't really understand why that helps, but it's a simple thing to do and the performance improves. I did it with `msplit` as well, although in my benchmark I didn't really notice a speedup from that one. Maybe I should revert it?

In the best case cases for both `LogicT` and `SeqT`, the gap between them is now about 3.2x on my benchmark/machine, with `SeqT` being an overwhelming winner when doing many repeated `msplit`s.