### PR TITLE
Clean up observe API

### DIFF
--- a/bench/logic-performance.hs
+++ b/bench/logic-performance.hs
@@ -82,7 +82,7 @@ runLSeqT_I :: L.Seq a -> [a]
 runLSeqT_I = L.observeAll
 
 runLSeqT_S :: (forall s. L.SeqT (ST s) a) -> [a]
-runLSeqT_S ma = runST (L.observeAllT ma)
+runLSeqT_S ma = runST (L.observeTAll ma)
 
 ------------------------------------------------------------------------
 -- Measured codes

--- a/bench/logic-performance.hs
+++ b/bench/logic-performance.hs
@@ -82,7 +82,7 @@ runLSeqT_I :: L.Seq a -> [a]
 runLSeqT_I = L.observeAll
 
 runLSeqT_S :: (forall s. L.SeqT (ST s) a) -> [a]
-runLSeqT_S ma = runST (L.observeTAll ma)
+runLSeqT_S ma = runST (L.observeAllT ma)
 
 ------------------------------------------------------------------------
 -- Measured codes

--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -24,7 +24,7 @@ module Control.Monad.Logic.Sequence
   , View(..)
   , toView
   , fromView
-  , observeAllT
+  , observeTAll
   , observeAll
   , observeT
   , observe

--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -28,7 +28,7 @@ module Control.Monad.Logic.Sequence
   , observeAll
   , observeT
   , observe
-  , observeMaybeT
+  , observeTMaybe
   , observeMaybe
   , module Control.Monad
   , module Control.Monad.Trans

--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -24,12 +24,10 @@ module Control.Monad.Logic.Sequence
   , View(..)
   , toView
   , fromView
-  , observeTAll
+  , observeAllT
   , observeAll
   , observeT
   , observe
-  , observeTMaybe
-  , observeMaybe
   , module Control.Monad
   , module Control.Monad.Trans
 )

--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -26,6 +26,8 @@ module Control.Monad.Logic.Sequence
   , fromView
   , observeAllT
   , observeAll
+  , observeManyT
+  , observeMany
   , observeT
   , observe
   , module Control.Monad

--- a/src/Control/Monad/Logic/Sequence/Compat.hs
+++ b/src/Control/Monad/Logic/Sequence/Compat.hs
@@ -1,5 +1,27 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ViewPatterns #-}
 module Control.Monad.Logic.Sequence.Compat
   ( fromSeqT
   , toLogicT
-  , fromLogicT ) where
-import Control.Monad.Logic.Sequence.Internal
+  , fromLogicT
+  , observeT
+  , observe ) where
+
+import Control.Monad.Identity (Identity(..))
+import Control.Monad.Logic.Sequence.Internal hiding ( observeT, observe )
+
+#if !MIN_VERSION_base(4,13,0)
+observeT :: Monad m => SeqT m a -> m a
+#else
+observeT :: MonadFail m => SeqT m a -> m a
+#endif
+observeT (toView -> m) = m >>= go where
+  go (a :< _) = return a
+  go Empty = fail "No results."
+{-# INLINE observeT #-}
+
+observe :: Seq a -> a
+observe (toView -> m) = case runIdentity m of
+  a :< _ -> a
+  Empty -> error "No results."
+{-# INLINE observe #-}

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -36,7 +36,7 @@ module Control.Monad.Logic.Sequence.Internal
   , View(..)
   , toView
   , fromView
-  , observeAllT
+  , observeTAll
   , observeAll
   , observeT
   , observe
@@ -325,12 +325,12 @@ instance Monad m => MonadLogic (SeqT m) where
       Empty -> single Nothing
       a :< t -> single (Just (a, t))
 
-observeAllT :: Monad m => SeqT m a -> m [a]
-observeAllT (toView -> m) = m >>= go where
+observeTAll :: Monad m => SeqT m a -> m [a]
+observeTAll (toView -> m) = m >>= go where
   go (a :< t) = liftM (a:) (toView t >>= go)
   go _ = return []
-{-# INLINEABLE observeAllT #-}
-{-# SPECIALIZE INLINE observeAllT :: Seq a -> Identity [a] #-}
+{-# INLINEABLE observeTAll #-}
+{-# SPECIALIZE INLINE observeTAll :: Seq a -> Identity [a] #-}
 
 #if !MIN_VERSION_base(4,13,0)
 observeT :: Monad m => SeqT m a -> m a
@@ -360,7 +360,7 @@ observeMaybe = runIdentity . observeTMaybe
 {-# INLINE observeMaybe #-}
 
 observeAll :: Seq a -> [a]
-observeAll = runIdentity . observeAllT
+observeAll = runIdentity . observeTAll
 {-# INLINE observeAll #-}
 
 -- | Convert @'SeqT' m a@ to @t m a@ when @t@ is some other logic monad

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -38,6 +38,8 @@ module Control.Monad.Logic.Sequence.Internal
   , fromView
   , observeAllT
   , observeAll
+  , observeManyT
+  , observeMany
   , observeT
   , observe
   , fromSeqT
@@ -336,6 +338,13 @@ observeT (toView -> m) = m >>= go where
   go Empty = return Nothing
 {-# INLINE observeT #-}
 
+observeManyT :: Monad m => Int -> SeqT m a -> m [a]
+observeManyT k m = toView m >>= go k where
+  go n _ | n <= 0 = return []
+  go _ Empty = return []
+  go n (a :< t) = liftM (a:) (observeManyT (n-1) t)
+{-# INLINEABLE observeManyT #-}
+
 observe :: Seq a -> Maybe a
 observe = runIdentity . observeT
 {-# INLINE observe #-}
@@ -343,6 +352,10 @@ observe = runIdentity . observeT
 observeAll :: Seq a -> [a]
 observeAll = runIdentity . observeAllT
 {-# INLINE observeAll #-}
+
+observeMany :: Int -> Seq a -> [a]
+observeMany n = runIdentity . observeManyT n
+{-# INLINE observeMany #-}
 
 -- | Convert @'SeqT' m a@ to @t m a@ when @t@ is some other logic monad
 -- transformer.

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -40,7 +40,7 @@ module Control.Monad.Logic.Sequence.Internal
   , observeAll
   , observeT
   , observe
-  , observeMaybeT
+  , observeTMaybe
   , observeMaybe
   , fromSeqT
   , hoistPre
@@ -342,21 +342,21 @@ observeT (toView -> m) = m >>= go where
   go Empty = fail "No results."
 {-# INLINE observeT #-}
 
-observe :: Seq a -> a
+observe :: Seq a -> Maybe a
 observe (toView -> m) = case runIdentity m of
-  a :< _ -> a
-  Empty -> error "No results."
+  a :< _ -> Just a
+  Empty -> Nothing
 {-# INLINE observe #-}
 
-observeMaybeT :: Monad m => SeqT m (Maybe a) -> m (Maybe a)
-observeMaybeT (toView -> m) = m >>= go where
+observeTMaybe :: Monad m => SeqT m (Maybe a) -> m (Maybe a)
+observeTMaybe (toView -> m) = m >>= go where
   go (Just a :< _) = return (Just a)
   go (Nothing :< rest) = toView rest >>= go
   go Empty = return Nothing
-{-# INLINEABLE observeMaybeT #-}
+{-# INLINEABLE observeTMaybe #-}
 
 observeMaybe :: Seq (Maybe a) -> Maybe a
-observeMaybe = runIdentity . observeMaybeT
+observeMaybe = runIdentity . observeTMaybe
 {-# INLINE observeMaybe #-}
 
 observeAll :: Seq a -> [a]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -121,7 +121,7 @@ main = hspec $ do
   describe "observeT" $ do
     it "undoes lift" $ hedgehog $ do
       ex <- forAll simpleTestM
-      runMaybeT (Compat.observeT (lift (lift ex))) === runMaybeT (lift ex)
+      observeT (lift ex) === (Just <$> ex)
   describe "observeAllT" $ do
     it "undoes lift" $ hedgehog $ do
       ex <- forAll simpleTestM
@@ -227,7 +227,7 @@ main = hspec $ do
           x <- local (5+) ask
           y <- ask
           return (x, y)
-      runReader (runMaybeT (Compat.observeT foo)) 0 `shouldBe` Just (5, 0)
+      runReader (observeT foo) 0 `shouldBe` Just (5, 0)
   describe "MFunctor instance" $ do
     it "obeys the hoist identity law" $ hedgehog $ do
       s <- forAll simpleSeqT


### PR DESCRIPTION
This is intended to close #8 

It renames `observeMaybeT` to `observeTMaybe` to avoid confusion with `MaybeT`. Also rename `observeAllT` to `observeTAll` to be consistent.

This also changes `observe` to have type `Seq a -> Maybe a` so that the no results case is no longer an implicit exception.

@treeowl  No rush on this, but please review when you have time.