### PR TITLE
More MonadLogic methods

### DIFF
--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -22,6 +22,7 @@ module Control.Monad.Logic.Sequence
   , getSeq
 #endif
   , View(..)
+  , view
   , toView
   , fromView
   , cons

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -68,6 +68,7 @@ import Control.Monad.Reader.Class (MonadReader (..))
 import Control.Monad.State.Class (MonadState (..))
 import Control.Monad.Error.Class (MonadError (..))
 import Control.Monad.Morph (MFunctor (..))
+import Data.SequenceClass hiding ((:<), empty)
 import qualified Data.SequenceClass as S
 import Control.Monad.Logic.Sequence.Internal.Queue (Queue)
 import qualified Text.Read as TR

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -68,7 +68,6 @@ import Control.Monad.Reader.Class (MonadReader (..))
 import Control.Monad.State.Class (MonadState (..))
 import Control.Monad.Error.Class (MonadError (..))
 import Control.Monad.Morph (MFunctor (..))
-import Data.SequenceClass hiding ((:<), empty)
 import qualified Data.SequenceClass as S
 import Control.Monad.Logic.Sequence.Internal.Queue (Queue)
 import qualified Text.Read as TR


### PR DESCRIPTION
* Write custom implementations of all the `MonadLogic` methods.
  The current defaults are pretty inefficient, though they'll
  be fixed shortly https://github.com/Bodigrim/logict/pull/23.
  Moreover, we can avoid some unnecessary `toView . fromView` gunk
  by writing our own.

* Add property tests for `lift`, `msplit`, and `ifte`. Add unit tests for
  the rest of `MonadLogic`.

* Add a catamorphism for `View`.