### PR TITLE
Add conversions from lists

### DIFF
--- a/src/Control/Monad/Logic/Sequence.hs
+++ b/src/Control/Monad/Logic/Sequence.hs
@@ -24,6 +24,10 @@ module Control.Monad.Logic.Sequence
   , View(..)
   , toView
   , fromView
+  , cons
+  , consM
+  , choose
+  , chooseM
   , observeAllT
   , observeAll
   , observeManyT

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -49,6 +49,10 @@ module Control.Monad.Logic.Sequence.Internal
   , hoistPostUnexposed
   , toLogicT
   , fromLogicT
+  , cons
+  , consM
+  , choose
+  , chooseM
 )
 where
 
@@ -267,6 +271,16 @@ altView (toView -> m) n = m >>= \x -> case x of
     where cat (SeqT l) (SeqT r) = SeqT (l S.>< r)
 {-# INLINE altView #-}
 
+-- | @cons a s = pure a <|> s@
+cons :: Monad m => a -> SeqT m a -> SeqT m a
+cons a s = fromView (return (a :< s))
+{-# INLINE cons #-}
+
+-- | @consM m s = lift m <|> s@
+consM :: Monad m => m a -> SeqT m a -> SeqT m a
+consM m s = fromView (liftM (:< s) m)
+{-# INLINE consM #-}
+
 instance Monad m => Monad (SeqT m) where
   {-# INLINE return #-}
   {-# INLINEABLE (>>=) #-}
@@ -324,6 +338,23 @@ instance Monad m => MonadLogic (SeqT m) where
     case r of
       Empty -> single Nothing
       a :< t -> single (Just (a, t))
+
+-- | @choose = foldr (\a s -> pure a <|> s) empty@
+--
+-- @choose :: Monad m => [a] -> SeqT m a@
+choose :: (F.Foldable t, Monad m) => t a -> SeqT m a
+choose = F.foldr cons empty
+{-# INLINABLE choose #-}
+
+-- | @chooseM = foldr (\ma s -> lift ma <|> s) empty@
+--
+-- @chooseM :: Monad m => [m a] -> SeqT m a@
+chooseM :: (F.Foldable t, Monad m) => t (m a) -> SeqT m a
+-- The idea here, which I hope is sensible, is to avoid building and
+-- restructuring queues unnecessarily. We end up building only *singleton*
+-- queues, which should hopefully be pretty cheap.
+chooseM = F.foldr consM empty
+{-# INLINABLE chooseM #-}
 
 observeAllT :: Monad m => SeqT m a -> m [a]
 observeAllT (toView -> m) = m >>= go where


### PR DESCRIPTION
* Add `choose` and `chooseM` to convert from lists of elements
  and lists of actions, respectively.

* Add `cons` and `consM` to add an element or action onto the
  front of a `SeqT`.