### PR TITLE
Avoid unnecessary empty insertion

### DIFF
--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -328,7 +328,7 @@ instance Monad m => Alternative (SeqT m) where
   {-# INLINE empty #-}
   {-# INLINEABLE (<|>) #-}
   empty = SeqT S.empty
-  m <|> n = fromViewT (altViewT m n)
+  SeqT m <|> SeqT n = SeqT (m S.>< n)
 
 altViewT :: Monad m => SeqT m a -> SeqT m a -> m (ViewT m a)
 altViewT (toViewT -> m) n = m >>= \x -> case x of


### PR DESCRIPTION
* The change to `linkAll` to fix the laziness bug introduced some `Empty` insertions that didn't need to happen for laziness. Get rid of those ones.
* Simplify the definition of `<|>`. The previous one resulted from an earlier (unsuccessful) attempt (by Atze?) to fix the laziness bug. Now that we've pushed laziness into the queue, we can do the simple thing there.