### PR TITLE
Work around instance loop bug

### DIFF
--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -22,6 +22,14 @@
 
 {-# LANGUAGE Trustworthy #-}
 {-# OPTIONS_HADDOCK not-home #-}
+#if __GLASGOW_HASKELL__ >= 904
+-- We need this for now to work around
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/22549
+-- which otherwise causes infinite loops in several
+-- instances.
+{-# OPTIONS_GHC -fno-dicts-strict #-}
+#endif
+
 {- OPTIONS_GHC -ddump-simpl -dsuppress-coercions #-}
 
 -- | Based on the LogicT improvements in the paper, Reflection without

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -404,13 +404,11 @@ main = hspec $ do
       f :: Int -> [Int] <- Fun.forAllFn (Fun.fn (Gen.list (Range.linear 0 5) (Gen.int (Range.constant 0 10000))))
       foldMap f s === foldMap f (Compat.toLogicT s)
 
-#if __GLASGOW_HASKELL__ != 904
   describe "traverse" $ do
     it "works like LogicT" $ hedgehog $ do
       s <- forAll simpleSeq
       f :: Int -> Identity Int <- (Identity .) <$> Fun.forAllFn (Fun.fn (Gen.int (Range.constant 0 10000)))
       traverse f s === (Compat.fromLogicT <$> traverse f (Compat.toLogicT s))
-#endif
 
 -- -------
 -- Reimplementation of Control.Monad.Free without the need


### PR DESCRIPTION
By default, GHC 9.4 produces looping behavior in several instances for `SeqT Identity a`. Turn off `-fdicts-strict` to work around that.

Upstream ticket: https://gitlab.haskell.org/ghc/ghc/-/issues/22549