### PR TITLE
Remove excessive laziness

### DIFF
--- a/logict-sequence.cabal
+++ b/logict-sequence.cabal
@@ -43,6 +43,7 @@ library
                     , Control.Monad.Logic.Sequence.Internal
                     , Control.Monad.Logic.Sequence.Internal.Queue
                     , Control.Monad.Logic.Sequence.Internal.ScheduledQueue
+                    , Control.Monad.Logic.Sequence.Internal.Any
 
     -- Modules included in this library but not exported.
     -- other-modules:

--- a/src/Control/Monad/Logic/Sequence/Internal.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal.hs
@@ -22,11 +22,12 @@
 
 {-# LANGUAGE Trustworthy #-}
 {-# OPTIONS_HADDOCK not-home #-}
-#if __GLASGOW_HASKELL__ >= 904
+#if __GLASGOW_HASKELL__ >= 902
 -- We need this for now to work around
--- https://gitlab.haskell.org/ghc/ghc/-/issues/22549
--- which otherwise causes infinite loops in several
--- instances.
+-- https://gitlab.haskell.org/ghc/ghc/-/issues/22549 which otherwise causes
+-- infinite loops in several instances. It's definitely needed for GHC 9.4; we
+-- do it for 9.2 as well just in case, as others have gotten loops with
+-- -fdicts-strict with that version.
 {-# OPTIONS_GHC -fno-dicts-strict #-}
 #endif
 

--- a/src/Control/Monad/Logic/Sequence/Internal/Any.hs
+++ b/src/Control/Monad/Logic/Sequence/Internal/Any.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
+-- We suppress this warning because otherwise GHC complains
+-- about the newtype constructor not being used.
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+#endif
+
+-- | It's safe to coerce /to/ 'Any' as long as you don't
+-- coerce back. We define our own 'Any' instead of using
+-- the one in "GHC.Exts" directly to ensure that this
+-- module doesn't clash with one making the opposite
+-- assumption. We use a newtype rather than a closed type
+-- family with no instances because the latter weren't supported
+-- until 8.0.
+module Control.Monad.Logic.Sequence.Internal.Any
+  ( Any
+  , toAnyList
+  ) where
+
+import Unsafe.Coerce
+import qualified GHC.Exts as E
+
+newtype Any = Any E.Any
+
+-- | Convert a list of anything to a list of 'Any'.
+toAnyList :: [a] -> [Any]
+toAnyList = unsafeCoerce


### PR DESCRIPTION
Partially reverts
a2a3a0c7e47cf51da402aee7483071ed35d11f0d

Go back to unpacking scheduled queues in catenable queues.

I mistakenly thought that the scheduled queues had to be suspended lazily in the tails of the catenable queues. This was incorrect. The only changes that were actually required were to stop trying to discard `Empty` in the second argument of `><` and to adjust `linkAll` to deal with the possible presence of `Empty`.