### PR TITLE
Bump the logict version bound

### DIFF
--- a/logict-sequence.cabal
+++ b/logict-sequence.cabal
@@ -52,7 +52,7 @@ library
     build-depends: base >=4.5 && <5
     build-depends: mtl >=2.0 && <2.3
     build-depends: sequence >= 0.9.8 && < 0.10
-    build-depends: logict >= 0.7.1.0 && < 0.8
+    build-depends: logict >= 0.7.1.0 && < 0.9
     build-depends: mmorph
     build-depends: transformers
 


### PR DESCRIPTION
The library builds with this version bump, but unfortunately I can't run the test suite. Below is what happens when I try to run the tests. I'm afraid I don't know how to fix that.

% cabal test
Resolving dependencies...
Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - HUnit-1.6.2.0 (lib) (requires build)
 - StateVar-1.2.2 (lib) (requires build)
 - happy-lib-2.1.5 (lib:frontend) (requires build)
 - haskell-lexer-1.2.1 (lib) (requires download & build)
 - logict-sequence-0.2.0.2 (lib) (first run)
 - logict-sequence-0.2.0.2 (test:do-nothing) (first run)
 - unliftio-core-0.2.1.0 (lib) (requires build)
 - primitive-0.9.0.0 (lib) (requires build)
 - erf-2.0.0.0 (lib:erf) (requires download & build)
 - random-1.3.0 (lib) (requires download & build)
 - os-string-2.0.7 (lib) (requires build)
 - safe-exceptions-0.1.7.4 (lib) (requires download & build)
 - tagged-0.8.9 (lib) (requires build)
 - transformers-base-0.4.6 (lib) (requires build)
 - wl-pprint-annotated-0.1.0.1 (lib) (requires download & build)
 - hspec-expectations-0.8.4 (lib) (requires build)
 - contravariant-1.5.5 (lib) (requires build)
 - happy-lib-2.1.5 (lib) (requires build)
 - resourcet-1.3.0 (lib) (requires build)
 - tf-random-0.5 (lib) (requires build)
 - QuickCheck-2.15.0.1 (lib) (requires build)
 - filepath-1.5.4.0 (lib) (requires build)
 - distributive-0.6.2.1 (lib) (requires build)
 - boring-0.2.2 (lib) (requires download & build)
 - monad-control-1.0.3.1 (lib) (requires build)
 - happy-2.1.5 (exe:happy) (requires build)
 - quickcheck-io-0.2.0 (lib) (requires build)
 - unix-2.8.6.0 (lib:unix) (requires build)
 - hashable-1.5.0.0 (lib) (requires build)
 - barbies-2.1.1.0 (lib) (requires download & build)
 - lifted-base-0.2.3.12 (lib) (requires build)
 - pretty-show-1.10 (lib) (requires download & build)
 - file-io-0.1.5 (lib) (requires build)
 - async-2.2.5 (lib) (requires download & build)
 - constraints-0.14.2 (lib) (requires download & build)
 - directory-1.3.9.0 (lib:directory) (requires build)
 - lifted-async-0.10.2.7 (lib) (requires download & build)
 - process-1.6.25.0 (lib:process) (requires build)
 - hspec-discover-2.11.12 (lib) (requires download & build)
 - hspec-core-2.11.12 (lib) (requires download & build)
 - hsc2hs-0.68.10 (exe:hsc2hs) (requires build)
 - hspec-2.11.12 (lib) (requires download & build)
 - terminal-size-0.3.4 (lib) (requires build)
 - concurrent-output-1.10.21 (lib) (requires download & build)
 - hedgehog-1.5 (lib) (requires download & build)
 - hspec-hedgehog-0.3.0.0 (lib) (requires download & build)
 - hedgehog-fn-1.0 (lib) (requires download & build)
 - logict-sequence-0.2.0.2 (test:logict-test) (first run)
Downloading  haskell-lexer-1.2.1
Starting     StateVar-1.2.2 (lib)
Starting     unliftio-core-0.2.1.0 (lib)
Configuring library for logict-sequence-0.2.0.2...
Configuring test suite 'do-nothing' for logict-sequence-0.2.0.2...
Starting     primitive-0.9.0.0 (lib)
Starting     HUnit-1.6.2.0 (lib)
Starting     happy-lib-2.1.5 (lib:frontend)
Downloaded   haskell-lexer-1.2.1
Downloading  erf-2.0.0.0
Starting     haskell-lexer-1.2.1 (lib)
Downloaded   erf-2.0.0.0
Downloading  random-1.3.0
Building     StateVar-1.2.2 (lib)
Downloaded   random-1.3.0
Downloading  boring-0.2.2
Building     happy-lib-2.1.5 (lib:frontend)
Building     unliftio-core-0.2.1.0 (lib)
Building     HUnit-1.6.2.0 (lib)
Building     primitive-0.9.0.0 (lib)
Preprocessing test suite 'do-nothing' for logict-sequence-0.2.0.2...
Building test suite 'do-nothing' for logict-sequence-0.2.0.2...
Preprocessing library for logict-sequence-0.2.0.2...
Building library for logict-sequence-0.2.0.2...
[1 of 1] Compiling Main             ( test/do-nothing.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/t/do-nothing/build/do-nothing/do-nothing-tmp/Main.o )
Downloaded   boring-0.2.2
Downloading  barbies-2.1.1.0
Building     haskell-lexer-1.2.1 (lib)
[2 of 2] Linking /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/t/do-nothing/build/do-nothing/do-nothing
Downloaded   barbies-2.1.1.0
Downloading  hspec-discover-2.11.12
[1 of 6] Compiling Control.Monad.Logic.Sequence.Internal.ScheduledQueue ( src/Control/Monad/Logic/Sequence/Internal/ScheduledQueue.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal/ScheduledQueue.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal/ScheduledQueue.dyn_o )
ld: warning: -U option is redundant when using -undefined dynamic_lookup
Downloaded   hspec-discover-2.11.12
Downloading  safe-exceptions-0.1.7.4
Downloaded   safe-exceptions-0.1.7.4
Downloading  constraints-0.14.2
Installing   unliftio-core-0.2.1.0 (lib)
Installing   StateVar-1.2.2 (lib)
Downloaded   constraints-0.14.2
Downloading  async-2.2.5
Error: [Cabal-9341]
Failed to find the installed unit 'logict-sequence-0.2.0.2-inplace' in package database stack.

Starting     erf-2.0.0.0 (all, legacy fallback: cabal-version is less than 1.8)
[2 of 6] Compiling Control.Monad.Logic.Sequence.Internal.Queue ( src/Control/Monad/Logic/Sequence/Internal/Queue.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal/Queue.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal/Queue.dyn_o )
Completed    StateVar-1.2.2 (lib)
Downloaded   async-2.2.5
Downloading  concurrent-output-1.10.21
Completed    unliftio-core-0.2.1.0 (lib)
[3 of 6] Compiling Control.Monad.Logic.Sequence.Internal ( src/Control/Monad/Logic/Sequence/Internal.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Internal.dyn_o )
Downloaded   concurrent-output-1.10.21
Downloading  lifted-async-0.10.2.7
Building     erf-2.0.0.0 (all, legacy fallback: cabal-version is less than 1.8)
Downloaded   lifted-async-0.10.2.7
Downloading  pretty-show-1.10
Installing   HUnit-1.6.2.0 (lib)
Completed    HUnit-1.6.2.0 (lib)
Downloaded   pretty-show-1.10
Downloading  wl-pprint-annotated-0.1.0.1
Downloaded   wl-pprint-annotated-0.1.0.1
Downloading  hedgehog-1.5
Installing   erf-2.0.0.0 (all, legacy fallback: cabal-version is less than 1.8)
[4 of 6] Compiling Control.Monad.Logic.Sequence.Compat ( src/Control/Monad/Logic/Sequence/Compat.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Compat.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Compat.dyn_o )
[5 of 6] Compiling Control.Monad.Logic.Sequence ( src/Control/Monad/Logic/Sequence.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence.dyn_o )
[6 of 6] Compiling Control.Monad.Logic.Sequence.Morph ( src/Control/Monad/Logic/Sequence/Morph.hs, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Morph.o, /Users/josefs/repos/logict-sequence/dist-newstyle/build/aarch64-osx/ghc-9.8.2/logict-sequence-0.2.0.2/build/Control/Monad/Logic/Sequence/Morph.dyn_o )
Completed    erf-2.0.0.0 (all, legacy fallback: cabal-version is less than 1.8)
Downloaded   hedgehog-1.5
Downloading  hedgehog-fn-1.0
Downloaded   hedgehog-fn-1.0
Downloading  hspec-core-2.11.12
Downloaded   hspec-core-2.11.12
Downloading  hspec-2.11.12
Downloaded   hspec-2.11.12
Downloading  hspec-hedgehog-0.3.0.0
Downloaded   hspec-hedgehog-0.3.0.0
Installing   happy-lib-2.1.5 (lib:frontend)
Completed    happy-lib-2.1.5 (lib:frontend)
Installing   primitive-0.9.0.0 (lib)
Completed    primitive-0.9.0.0 (lib)
Installing   haskell-lexer-1.2.1 (lib)
Completed    haskell-lexer-1.2.1 (lib)
Error: [Cabal-7125]
Tests failed for test:do-nothing from logict-sequence-0.2.0.2.
